### PR TITLE
Allow for a function or a node

### DIFF
--- a/connect.js
+++ b/connect.js
@@ -2,7 +2,7 @@ var components = require("./components"), observer = require("./index")
 
 function connect (el, c, l, m, r) {
   var id = "a" + parseInt(Math.random() * 10000000), f = function(){}
-  c && c(id); el = el()
+  c && c(id); el = typeof el === 'function' ? el() : el
   el.dataset.tdid = id
   components[id] = {
     node: el, added: (l || f), mutated: (m || f), removed: (r || f)


### PR DESCRIPTION
Make it easier to wrap any node in connect by allowing for either a function
or the actual node to be passed in.

Likely prevents `constructed` from being detected, but since it's already
constructed elsewhere that would make logical sense if you use it in this
fashion.
